### PR TITLE
KeyguardIndicationController: Fix compile error

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardIndicationController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardIndicationController.java
@@ -589,8 +589,6 @@ public class KeyguardIndicationController implements StateListener,
             }
         }
 
-        String percentage = NumberFormat.getPercentInstance()
-                .format(mBatteryLevel / 100f);
         if (hasChargingTime) {
             // We now have battery percentage in these strings and it's expected that all
             // locales will also have it in the future. For now, we still have to support the old


### PR DESCRIPTION
This cause compile error, because variable was declared redundant. and I don't think it's necessary.